### PR TITLE
Summary: Make cbor-diag examples parsable even with elisions

### DIFF
--- a/rfc9203.xml
+++ b/rfc9203.xml
@@ -300,8 +300,8 @@ Usually, it is assumed that constrained devices will be preconfigured with the n
     Content-Type: application/ace+cbor
     Payload:
     {
-      / access_token / 1 : h'8343a1010aa2044c53 ...
-       (remainder of access token (CWT) omitted for brevity)',
+      / access_token / 1 : h'8343a1010aa2044c53/...
+       (remainder of access token (CWT) omitted for brevity)/',
       / ace_profile / 38 : / coap_oscore / 2,
         / expires_in / 2 : 3600,
                / cnf / 8 : {
@@ -379,8 +379,8 @@ A5                              # map(5)
     Content-Type: application/ace+cbor
     Payload:
     {
-      / access_token / 1 : h'8343a1010aa2044c53 ...
-       (remainder of access token (CWT) omitted for brevity)',
+      / access_token / 1 : h'8343a1010aa2044c53/ ...
+       (remainder of access token (CWT) omitted for brevity)/',
       / ace_profile / 38 : / coap_oscore / 2,
         / expires_in / 2 : 3600
     }
@@ -604,8 +604,8 @@ The client <bcp14>MUST</bcp14> use the Content-Format application/ace+cbor defin
       Content-Format: application/ace+cbor
       Payload:
         {
-                     / access_token / 1 : h'8343a1010aa2044c53 ...
-       (remainder of access token (CWT) omitted for brevity)',
+                     / access_token / 1 : h'8343a1010aa2044c53/...
+       (remainder of access token (CWT) omitted for brevity)/',
                           / nonce1 / 40 : h'018a278f7faab55a',
           / ace_client_recipientid / 43 : h'1645'
         }


### PR DESCRIPTION
One way to make cbor-diag with elisions parsable